### PR TITLE
ethash: fix undefined `Sha3Hash` function

### DIFF
--- a/ethash.go
+++ b/ethash.go
@@ -433,7 +433,7 @@ func GetSeedHash(blockNum uint64) ([]byte, error) {
 
 func makeSeedHash(epoch uint64) (sh common.Hash) {
 	for ; epoch > 0; epoch-- {
-		sh = crypto.Sha3Hash(sh[:])
+		sh = crypto.Keccak256Hash(sh[:])
 	}
 	return sh
 }

--- a/ethash_test.go
+++ b/ethash_test.go
@@ -79,10 +79,10 @@ var validBlocks = []*testBlock{
 
 var invalidZeroDiffBlock = testBlock{
 	number:      61440000,
-	hashNoNonce: crypto.Sha3Hash([]byte("foo")),
+	hashNoNonce: crypto.Keccak256Hash([]byte("foo")),
 	difficulty:  big.NewInt(0),
 	nonce:       0xcafebabec00000fe,
-	mixDigest:   crypto.Sha3Hash([]byte("bar")),
+	mixDigest:   crypto.Keccak256Hash([]byte("bar")),
 }
 
 func TestEthashVerifyValid(t *testing.T) {


### PR DESCRIPTION
The `Sha3Hash` function was removed from go-ethereum in the 1.6.x series:

commit 72dd51e25a5c1553a5a7fc5f0fb84fbe3546682f
Author: Péter Szilágyi <peterke@gmail.com>
Date:   Thu Jun 1 10:24:40 2017 +0300

Now we can just call `crypto.Keccak256Hash` directly.